### PR TITLE
Add option to disable items

### DIFF
--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -5,6 +5,7 @@ import Table from '../examples/Table';
 import SuperSimple from '../examples/SuperSimple';
 import Removable from '../examples/Removable';
 import Handle from '../examples/Handle';
+import Disabled from '../examples/Disabled';
 import NoAnimations from '../examples/NoAnimations';
 import LockVertically from '../examples/LockVertically';
 import VaryingHeights from '../examples/VaryingHeights';
@@ -17,6 +18,7 @@ storiesOf('List', module)
   .add('Super simple', () => <SuperSimple />)
   .add('Removable', () => <Removable />)
   .add('Handle', () => <Handle />)
+  .add('Disabled', () => <Disabled />)
   .add('No animations', () => <NoAnimations />)
   .add('Lock vertically', () => <LockVertically />)
   .add('Varying heights', () => <VaryingHeights />)

--- a/examples/Disabled.tsx
+++ b/examples/Disabled.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { List, arrayMove } from '../src/index';
+
+type TItems = { label: String; disabled?: boolean }[];
+
+class Disabled extends React.Component<{}, { items: TItems }> {
+  state = {
+    items: [
+      { label: 'Item 1' },
+      { label: 'Item 2' },
+      { label: 'Item 3' },
+      { label: 'Item 4', disabled: true },
+      { label: 'Item 5', disabled: true },
+      { label: 'Item 6' }
+    ]
+  };
+  render() {
+    return (
+      <div
+        style={{
+          maxWidth: '300px',
+          margin: '0px auto',
+          backgroundColor: '#F7F7F7',
+          padding: '3em'
+        }}
+      >
+        <List
+          values={this.state.items}
+          onChange={({ oldIndex, newIndex }) =>
+            this.setState((prevState: { items: TItems }) => ({
+              items: arrayMove(prevState.items, oldIndex, newIndex)
+            }))
+          }
+          renderList={({ children, props, isDragged }) => (
+            <ul
+              {...props}
+              style={{ padding: 0, cursor: isDragged ? 'grabbing' : undefined }}
+            >
+              {children}
+            </ul>
+          )}
+          renderItem={({ value, props, isDragged, isSelected }) => (
+            <li
+              {...props}
+              style={{
+                ...props.style,
+                padding: '1.5em',
+                margin: '0.5em 0em',
+                listStyleType: 'none',
+                cursor: isDragged
+                  ? 'grabbing'
+                  : value.disabled
+                  ? 'default'
+                  : 'grab',
+                border: '2px solid #CCC',
+                boxShadow: '3px 3px #AAA',
+                color: value.disabled ? '#888' : '#333',
+                borderRadius: '5px',
+                outline: value.disabled ? 'none' : undefined,
+                fontFamily: 'Arial, "Helvetica Neue", Helvetica, sans-serif',
+                backgroundColor:
+                  isDragged || isSelected
+                    ? '#EEE'
+                    : value.disabled
+                    ? '#EEE'
+                    : '#FFF'
+              }}
+            >
+              {value.label}
+            </li>
+          )}
+        />
+      </div>
+    );
+  }
+}
+
+export default Disabled;

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -136,7 +136,12 @@ class List<Value = string> extends React.Component<IProps<Value>> {
     const isTouch = isTouchEvent(e);
     if (!isTouch && e.button !== 0) return;
     const index = this.getTargetIndex(e as any);
-    if (index === -1) return;
+    if (
+      index === -1 ||
+      // @ts-ignore
+      (this.props.values[index] && this.props.values[index].disabled)
+    )
+      return;
     const listItemTouched = this.getChildren()[index];
     const handle = listItemTouched.querySelector('[data-movable-handle]');
     if (handle && !handle.contains(e.target as any)) {
@@ -459,9 +464,12 @@ class List<Value = string> extends React.Component<IProps<Value>> {
           children: this.props.values.map((value, index) => {
             const isHidden = index === this.state.itemDragged;
             const isSelected = index === this.state.selectedItem;
+            const isDisabled =
+              // @ts-ignore
+              this.props.values[index] && this.props.values[index].disabled;
             const props: IItemProps = {
               key: index,
-              tabIndex: 0,
+              tabIndex: isDisabled ? -1 : 0,
               'aria-roledescription': this.props.voiceover.item(index + 1),
               onKeyDown: this.onKeyDown,
               style: {


### PR DESCRIPTION
Solves #6 
Should help with #7 

**[PREVIEW](https://deploy-preview-9--react-movable.netlify.com/?selectedKind=List&selectedStory=Disabled&full=0&addons=0&stories=1&panelRight=0)**

A simple way to disable drag and drop for an item by turning items into objects and adding a special prop `disabled`.

```jsx
<List values={[
  { label: 'Item 1' },
  { label: 'Item 2' },
  { label: 'Item 3' },
  { label: 'Item 4', disabled: true },
  { label: 'Item 5', disabled: true },
  { label: 'Item 6' }
]} />
```

What do you think @VuongN and @drcmda?