### PR TITLE
Expose more events

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,27 @@ The List component is `stateless` and `controlled` so you need to implement this
 ### beforeDrag
 
 ```ts
-beforeDrag?: (params: { elements: Element[]; index: number }) => void;
+beforeDrag?: (params: { elements: Element[]; index: number; targetRect: ClientRect }) => void;
 ```
 
-Called when a valid drag is initiated. It provides a direct access to all list DOM elements and the index of dragged item. This can be useful when you need to do some upfront measurements like when building a [table with variable column widths](https://react-movable.netlify.com/?selectedKind=List&selectedStory=Table%20Auto%20Cell%20Widths).
+Called when a valid drag is initiated. It provides a direct access to all list DOM elements, the index and the ClientRect of the dragged item. This can be useful when you need to do some upfront measurements like when building a [table with variable column widths](https://react-movable.netlify.com/?selectedKind=List&selectedStory=Table%20Auto%20Cell%20Widths).
+
+### onMove
+
+```ts
+onMove?: (params: { clientX: number; clientY: number }) => void;
+```
+
+Called when item is being dragged with a cursor. It provides an object with current cursor position (clientX, clientY) as an argument. Since this callback is introduced to provide the cursor coordinates, it is not triggered when items are moved with keyboard shortcuts. For this case, the cursor position would be irrelevant.
+
+
+### afterDrag
+
+```ts
+afterDrag?: (params: { elements: Element[]; targetRect: ClientRect }) => void
+```
+
+Called when a valid drag is finished. It provides a direct access to all list DOM elements, the updated index and the ClientRect of the dragged item. This callback is called right before the `onChange` event.
 
 ### removableByMove
 

--- a/flowtypes/List.js.flow
+++ b/flowtypes/List.js.flow
@@ -41,7 +41,17 @@ declare interface IListProps<Value> {
   }) => mixed;
   beforeDrag?: (params: {
     elements: HTMLElement[],
-    index: number
+    index: number,
+    targetRect: ClientRect
+  }) => mixed;
+  onMove?: (meta: {
+    clientX: number,
+    clientY: number,
+  }) => mixed;
+  afterDrag?: (params: {
+    elements: HTMLElement[],
+    index: number,
+    targetRect: ClientRect
   }) => mixed;
   transitionDuration?: number;
   removableByMove?: boolean;

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -242,6 +242,7 @@ class List<Value = string> extends React.Component<IProps<Value>> {
       clientY - this.state.initialY,
       this.props.lockVertically ? 0 : clientX - this.state.initialX
     );
+    this.props.onMove && this.props.onMove({ clientX, clientY });
     this.autoScrolling(clientY);
     this.moveOtherItems();
   };

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -429,14 +429,23 @@ class List<Value = string> extends React.Component<IProps<Value>> {
   finishDrop = () => {
     const removeItem =
       this.props.removableByMove && this.isDraggedItemOutOfBounds();
+    const oldIndex = this.state.itemDragged;
+    const newIndex = removeItem ? -1 : Math.max(this.afterIndex, 0);
+    const targetRect = this.ghostRef.current!.getBoundingClientRect();
+    this.props.afterDrag &&
+      this.props.afterDrag({
+        elements: this.getChildren(),
+        index: newIndex,
+        targetRect
+      });
     if (
       removeItem ||
       (this.afterIndex > -2 && this.state.itemDragged !== this.afterIndex)
     ) {
       this.props.onChange({
-        oldIndex: this.state.itemDragged,
-        newIndex: removeItem ? -1 : Math.max(this.afterIndex, 0),
-        targetRect: this.ghostRef.current!.getBoundingClientRect()
+        oldIndex,
+        newIndex,
+        targetRect
       });
     }
     this.getChildren().forEach(item => {

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -160,10 +160,12 @@ class List<Value = string> extends React.Component<IProps<Value>> {
       return;
     }
     e.preventDefault();
+    const elements = this.getChildren();
     this.props.beforeDrag &&
       this.props.beforeDrag({
-        elements: this.getChildren(),
-        index
+        elements,
+        index,
+        targetRect: elements[index].getBoundingClientRect()
       });
     if (isTouch) {
       const opts = { passive: false };

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface IItemProps {
 
 export interface IProps<Value> {
   beforeDrag?: (params: { elements: Element[]; index: number; targetRect: ClientRect }) => void;
+  afterDrag?: (params: { elements: Element[]; index: number; targetRect: ClientRect }) => void;
   renderItem: (params: {
     value: Value;
     props: IItemProps;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface IItemProps {
 }
 
 export interface IProps<Value> {
-  beforeDrag?: (params: { elements: Element[]; index: number }) => void;
+  beforeDrag?: (params: { elements: Element[]; index: number; targetRect: ClientRect }) => void;
   renderItem: (params: {
     value: Value;
     props: IItemProps;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface IItemProps {
 
 export interface IProps<Value> {
   beforeDrag?: (params: { elements: Element[]; index: number; targetRect: ClientRect }) => void;
+  onMove?: (params: { clientX: number; clientY: number }) => void;
   afterDrag?: (params: { elements: Element[]; index: number; targetRect: ClientRect }) => void;
   renderItem: (params: {
     value: Value;


### PR DESCRIPTION
Hi @tajo,

Here the commit with changes from issue #20. 

I called the new callback `afterDrag` as you suggested so that it matches to the existing `beforeDrag`. It is called right before `onChange` and contains the new index of the dragged element.

Both `beforeDrag` and `afterDrag` callbacks are now the ClientRect object. Since, we can't access the ghostRef when beforeDrag is called, I'm returning the ClientRect of the original DOM element.

Also, added `onMove` callback. I haven't implemented its triggered when list elements are moved with keyboard shortcuts as it contains the mouse coordinates and they are not quite relevant when moving the items with keyboard.

Regarding the tests, I haven't found any of them for `beforeDrag` in the existing codebase, so I haven't written tests for new callbacks. Let me know if you find them necessary. 

Thanks,
Andrey