### PR TITLE
fix: remove unnecessary "display: block"

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -547,7 +547,6 @@ class List<Value = string> extends React.Component<IProps<Value>> {
       left: this.state.targetX,
       width: this.state.targetWidth,
       height: this.state.targetHeight,
-      display: 'block',
       position: 'fixed',
       marginTop: 0
     } as React.CSSProperties;


### PR DESCRIPTION
As discussed on #37 , it's not necessary adding a `display:block` to ghost element.

Close
#37 