### PR TITLE
fix: touch scroll on elements with handle

### DIFF
--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -16,6 +16,7 @@ import ScrollingContainer from '../examples/ScrollingContainer';
 import InteractiveItems from '../examples/InteractiveItems';
 import CustomComponent from '../examples/CustomComponent';
 import CustomContainer from '../examples/CustomContainer';
+import ScrollingContainerHandle from '../examples/ScrollingContainerHandle';
 
 storiesOf('List', module)
   .add('Basic', () => <Basic />)
@@ -31,6 +32,7 @@ storiesOf('List', module)
   .add('Varying heights', () => <VaryingHeights />)
   .add('Scrolling window', () => <ScrollingWindow />)
   .add('Scrolling container', () => <ScrollingContainer />)
+  .add('Scrolling container with handle', () => <ScrollingContainerHandle />)
   .add('Interactive items', () => <InteractiveItems />)
   .add('Custom component', () => <CustomComponent />)
   .add('Custom container', () => <CustomContainer />);

--- a/examples/Handle.tsx
+++ b/examples/Handle.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { List, arrayMove, arrayRemove } from '../src/index';
 
-const HandleIcon = () => (
+export const HandleIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width="24"
@@ -23,7 +23,7 @@ const HandleIcon = () => (
   </svg>
 );
 
-const buttonStyles = {
+export const buttonStyles = {
   border: 'none',
   margin: 0,
   padding: 0,

--- a/examples/ScrollingContainerHandle.tsx
+++ b/examples/ScrollingContainerHandle.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { List, arrayMove } from '../src/index';
+import { buttonStyles, HandleIcon } from './Handle';
+
+const ScrollingContainerHandle: React.FC = () => {
+  const [items, setItems] = React.useState(
+    Array.from(Array(100).keys()).map((val) => `Item ${val}`)
+  );
+
+  return (
+    <div
+      style={{
+        maxWidth: '332px',
+        margin: '0px auto',
+        backgroundColor: '#F7F7F7',
+        padding: '3em'
+      }}
+    >
+      <List
+        values={items}
+        onChange={({ oldIndex, newIndex }) =>
+          setItems(arrayMove(items, oldIndex, newIndex))
+        }
+        renderList={({ children, props, isDragged }) => (
+          <ul
+            {...props}
+            style={{
+              padding: '1em',
+              cursor: isDragged ? 'grabbing' : undefined,
+              height: 600,
+              overflowY: 'scroll',
+              overflowX: 'hidden',
+              borderTop: '5px solid #AAA',
+              borderBottom: '5px solid #AAA'
+            }}
+          >
+            {children}
+          </ul>
+        )}
+        renderItem={({ value, props, isDragged, isSelected }) => (
+          <li
+            {...props}
+            style={{
+              ...props.style,
+              padding: '1.5em',
+              margin: '0.5em 0em',
+              listStyleType: 'none',
+              cursor: isDragged ? 'grabbing' : 'grab',
+              border: '2px solid #CCC',
+              boxShadow: '3px 3px #AAA',
+              color: '#333',
+              borderRadius: '5px',
+              fontFamily: 'Arial, "Helvetica Neue", Helvetica, sans-serif',
+              backgroundColor: isDragged || isSelected ? '#EEE' : '#FFF'
+            }}
+          >
+            <button
+              data-movable-handle
+              style={{
+                ...buttonStyles,
+                cursor: isDragged ? 'grabbing' : 'grab',
+                marginRight: '3em'
+              }}
+              tabIndex={-1}
+            >
+              <HandleIcon />
+            </button>
+            {value}
+          </li>
+        )}
+      />
+    </div>
+  );
+};
+
+export default ScrollingContainerHandle;

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -151,7 +151,7 @@ class List<Value = string> extends React.Component<IProps<Value>> {
       (this.props.values[index] && this.props.values[index].disabled)
     )
       return;
-    const listItemTouched = this.getChildren()[index];
+    const listItemTouched = this.getChildren()[index] as HTMLElement;
     const handle = listItemTouched.querySelector('[data-movable-handle]');
     if (handle && !handle.contains(e.target as any)) {
       return;
@@ -167,15 +167,23 @@ class List<Value = string> extends React.Component<IProps<Value>> {
       });
     if (isTouch) {
       const opts = { passive: false };
+      listItemTouched.style.touchAction = 'none';
       document.addEventListener('touchend', this.schdOnEnd, opts);
       document.addEventListener('touchmove', this.schdOnTouchMove, opts);
       document.addEventListener('touchcancel', this.schdOnEnd, opts);
     } else {
       document.addEventListener('mousemove', this.schdOnMouseMove);
       document.addEventListener('mouseup', this.schdOnEnd);
+
+      const listItemDragged = this.getChildren()[
+        this.state.itemDragged
+      ] as HTMLElement;
+      if (listItemDragged && listItemDragged.style) {
+        listItemDragged.style.touchAction = '';
+      }
     }
     this.onStart(
-      listItemTouched as HTMLElement,
+      listItemTouched,
       isTouch ? e.touches[0].clientX : e.clientX,
       isTouch ? e.touches[0].clientY : e.clientY,
       index
@@ -534,7 +542,6 @@ class List<Value = string> extends React.Component<IProps<Value>> {
   render() {
     const baseStyle = {
       userSelect: 'none',
-      touchAction: 'none',
       WebkitUserSelect: 'none',
       MozUserSelect: 'none',
       msUserSelect: 'none',


### PR DESCRIPTION
This PR tries to solve #30 and #13 issues. Basically I've removed `touchAction: none` on baseStyle and applied only when a touch element triggers `onMouseOrTouchStart`!

This enables elements with `data-movable-handle` to scroll when touching other areas.

Same as #39 