### PR TITLE
peerDependencies maintainable for further react versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "react": "^16.3.0-0 || ^17.0.0-0",
-    "react-dom": "^16.3.0-0 || ^17.0.0-0"
+    "react": ">=16.3",
+    "react-dom": ">=16.3"
   },
   "jest": {
     "roots": [


### PR DESCRIPTION
leave it ready for
- [x] react@^16.3
- [x] react@^17.0.X
- [x] react@18 in future with no changes https://reactjs.org/blog/2021/06/08/the-plan-for-react-18.html