### PR TITLE
fix: memory leak, clearTimeout and cancelAnimationFrame on componentWillUnmount

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -40,9 +40,9 @@ class List<Value = string> extends React.Component<IProps<Value>> {
     scrollingSpeed: 0,
     scrollWindow: false
   };
-  schdOnMouseMove: (e: MouseEvent) => void;
-  schdOnTouchMove: (e: TouchEvent) => void;
-  schdOnEnd: (e: Event) => void;
+  schdOnMouseMove: { (e: MouseEvent): void; cancel(): void; };
+  schdOnTouchMove: { (e: TouchEvent): void; cancel(): void; };
+  schdOnEnd: { (e: Event): void; cancel(): void; };
 
   constructor(props: IProps<Value>) {
     super(props);
@@ -75,6 +75,9 @@ class List<Value = string> extends React.Component<IProps<Value>> {
     if (this.dropTimeout) {
       window.clearTimeout(this.dropTimeout);
     }
+    this.schdOnMouseMove.cancel();
+    this.schdOnTouchMove.cancel();
+    this.schdOnEnd.cancel();
   }
 
   doScrolling = () => {

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -72,6 +72,9 @@ class List<Value = string> extends React.Component<IProps<Value>> {
   componentWillUnmount() {
     document.removeEventListener('touchstart', this.onMouseOrTouchStart as any);
     document.removeEventListener('mousedown', this.onMouseOrTouchStart as any);
+    if (this.dropTimeout) {
+      window.clearTimeout(this.dropTimeout);
+    }
   }
 
   doScrolling = () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,6 +92,11 @@ export const schd = (fn: Function) => {
       fn(...lastArgs);
     });
   };
+  wrapperFn.cancel = () => {
+    if (frameId) {
+      cancelAnimationFrame(frameId);
+    }
+  };
   return wrapperFn;
 };
 


### PR DESCRIPTION
closes https://github.com/tajo/react-movable/issues/73

When the List component is removed (via a click/touch), requestAnimationFrame is executed but not finished, so results in a memory leak.

this PR returns a cancel function from the `schd` util so we can cancel it on unmount. Also added clearTimeout just in case