### PR TITLE
feat: include `radio` and `switch` roles in the `DISABLED_ROLES` array

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,7 +114,7 @@ export function checkIfInteractive(target: Element, rootElement: Element) {
     'button',
     'a'
   ];
-  const DISABLED_ROLES = ['button', 'link', 'checkbox', 'tab'];
+  const DISABLED_ROLES = ['button', 'link', 'checkbox', 'radio', 'switch', 'tab'];
   while (target !== rootElement) {
     if (target.getAttribute('data-movable-handle')) {
       return false;


### PR DESCRIPTION
The current `DISABLED_ROLES` array does not include the `radio` and `switch` roles. This PR aims to extend interactive element support by checking the roles for Radio and Switch components.

* ARIA: radio role
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/radio_role
* ARIA: switch role
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role