### PR TITLE
Improve autoscroll on short windows/containers

### DIFF
--- a/examples/ScrollingContainerShort.tsx
+++ b/examples/ScrollingContainerShort.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { List, arrayMove } from '../src/index';
+
+const ScrollingContainerShort: React.FC = () => {
+  const [items, setItems] = React.useState(
+    Array.from(Array(100).keys()).map((val) => `Item ${val}`)
+  );
+
+  return (
+    <div
+      style={{
+        maxWidth: '332px',
+        margin: '0px auto',
+        backgroundColor: '#F7F7F7',
+        padding: '3em'
+      }}
+    >
+      <List
+        values={items}
+        onChange={({ oldIndex, newIndex }) =>
+          setItems(arrayMove(items, oldIndex, newIndex))
+        }
+        renderList={({ children, props, isDragged }) => (
+          <ul
+            {...props}
+            style={{
+              padding: '1em',
+              cursor: isDragged ? 'grabbing' : undefined,
+              height: 200,
+              overflowY: 'scroll',
+              overflowX: 'hidden',
+              borderTop: '5px solid #AAA',
+              borderBottom: '5px solid #AAA'
+            }}
+          >
+            {children}
+          </ul>
+        )}
+        renderItem={({ value, props, isDragged, isSelected }) => (
+          <li
+            {...props}
+            style={{
+              ...props.style,
+              padding: '1.5em',
+              margin: '0.5em 0em',
+              listStyleType: 'none',
+              cursor: isDragged ? 'grabbing' : 'grab',
+              border: '2px solid #CCC',
+              boxShadow: '3px 3px #AAA',
+              color: '#333',
+              borderRadius: '5px',
+              fontFamily: 'Arial, "Helvetica Neue", Helvetica, sans-serif',
+              backgroundColor: isDragged || isSelected ? '#EEE' : '#FFF'
+            }}
+          >
+            {value}
+          </li>
+        )}
+      />
+    </div>
+  );
+};
+
+export default ScrollingContainerShort;

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -13,6 +13,7 @@ import type { IItemProps, IProps, TEvent } from './types.js';
 
 const AUTOSCROLL_ACTIVE_OFFSET = 200;
 const AUTOSCROLL_SPEED_RATIO = 10;
+const AUTOSCROLL_DELTA_THRESHOLD = 10;
 
 class List<Value = string> extends React.Component<IProps<Value>> {
   listRef = React.createRef<HTMLElement>();
@@ -259,7 +260,7 @@ class List<Value = string> extends React.Component<IProps<Value>> {
       clientY - this.state.initialY,
       this.props.lockVertically ? 0 : clientX - this.state.initialX
     );
-    this.autoScrolling(clientY);
+    this.autoScrolling(clientY, clientY - this.state.initialY);
     this.moveOtherItems();
   };
 
@@ -289,7 +290,7 @@ class List<Value = string> extends React.Component<IProps<Value>> {
     );
   };
 
-  autoScrolling = (clientY: number) => {
+  autoScrolling = (clientY: number, delta: number) => {
     const { top, bottom, height } =
       this.listRef.current!.getBoundingClientRect();
     const viewportHeight =
@@ -297,7 +298,8 @@ class List<Value = string> extends React.Component<IProps<Value>> {
     // autoscrolling for the window (down)
     if (
       bottom > viewportHeight &&
-      viewportHeight - clientY < AUTOSCROLL_ACTIVE_OFFSET
+      viewportHeight - clientY < AUTOSCROLL_ACTIVE_OFFSET &&
+      delta > AUTOSCROLL_DELTA_THRESHOLD
     ) {
       this.setState({
         scrollingSpeed: Math.round(
@@ -307,7 +309,11 @@ class List<Value = string> extends React.Component<IProps<Value>> {
         scrollWindow: true
       });
       // autoscrolling for the window (up)
-    } else if (top < 0 && clientY < AUTOSCROLL_ACTIVE_OFFSET) {
+    } else if (
+      top < 0 &&
+      clientY < AUTOSCROLL_ACTIVE_OFFSET &&
+      delta < -AUTOSCROLL_DELTA_THRESHOLD
+    ) {
       this.setState({
         scrollingSpeed: Math.round(
           (AUTOSCROLL_ACTIVE_OFFSET - clientY) / -AUTOSCROLL_SPEED_RATIO
@@ -321,12 +327,20 @@ class List<Value = string> extends React.Component<IProps<Value>> {
       // autoscrolling for containers with overflow
       if (height + 20 < this.listRef.current!.scrollHeight) {
         let scrollingSpeed = 0;
-        if (clientY - top < AUTOSCROLL_ACTIVE_OFFSET) {
+        // (up)
+        if (
+          clientY - top < AUTOSCROLL_ACTIVE_OFFSET &&
+          delta < -AUTOSCROLL_DELTA_THRESHOLD
+        ) {
           scrollingSpeed = Math.round(
             (AUTOSCROLL_ACTIVE_OFFSET - (clientY - top)) /
               -AUTOSCROLL_SPEED_RATIO
           );
-        } else if (bottom - clientY < AUTOSCROLL_ACTIVE_OFFSET) {
+          // (down)
+        } else if (
+          bottom - clientY < AUTOSCROLL_ACTIVE_OFFSET &&
+          delta > AUTOSCROLL_DELTA_THRESHOLD
+        ) {
           scrollingSpeed = Math.round(
             (AUTOSCROLL_ACTIVE_OFFSET - (bottom - clientY)) /
               AUTOSCROLL_SPEED_RATIO

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -302,9 +302,14 @@ class List<Value = string> extends React.Component<IProps<Value>> {
       delta > AUTOSCROLL_DELTA_THRESHOLD
     ) {
       this.setState({
-        scrollingSpeed: Math.round(
-          (AUTOSCROLL_ACTIVE_OFFSET - (viewportHeight - clientY)) /
-            AUTOSCROLL_SPEED_RATIO
+        scrollingSpeed: Math.min(
+          Math.round(
+            (AUTOSCROLL_ACTIVE_OFFSET - (viewportHeight - clientY)) /
+              AUTOSCROLL_SPEED_RATIO
+          ),
+          Math.round(
+            (delta - AUTOSCROLL_DELTA_THRESHOLD) / AUTOSCROLL_SPEED_RATIO
+          )
         ),
         scrollWindow: true
       });
@@ -315,8 +320,13 @@ class List<Value = string> extends React.Component<IProps<Value>> {
       delta < -AUTOSCROLL_DELTA_THRESHOLD
     ) {
       this.setState({
-        scrollingSpeed: Math.round(
-          (AUTOSCROLL_ACTIVE_OFFSET - clientY) / -AUTOSCROLL_SPEED_RATIO
+        scrollingSpeed: Math.max(
+          Math.round(
+            (AUTOSCROLL_ACTIVE_OFFSET - clientY) / -AUTOSCROLL_SPEED_RATIO
+          ),
+          Math.round(
+            (delta + AUTOSCROLL_DELTA_THRESHOLD) / AUTOSCROLL_SPEED_RATIO
+          )
         ),
         scrollWindow: true
       });
@@ -332,18 +342,28 @@ class List<Value = string> extends React.Component<IProps<Value>> {
           clientY - top < AUTOSCROLL_ACTIVE_OFFSET &&
           delta < -AUTOSCROLL_DELTA_THRESHOLD
         ) {
-          scrollingSpeed = Math.round(
-            (AUTOSCROLL_ACTIVE_OFFSET - (clientY - top)) /
-              -AUTOSCROLL_SPEED_RATIO
+          scrollingSpeed = Math.max(
+            Math.round(
+              (AUTOSCROLL_ACTIVE_OFFSET - (clientY - top)) /
+                -AUTOSCROLL_SPEED_RATIO
+            ),
+            Math.round(
+              (delta + AUTOSCROLL_DELTA_THRESHOLD) / AUTOSCROLL_SPEED_RATIO
+            )
           );
           // (down)
         } else if (
           bottom - clientY < AUTOSCROLL_ACTIVE_OFFSET &&
           delta > AUTOSCROLL_DELTA_THRESHOLD
         ) {
-          scrollingSpeed = Math.round(
-            (AUTOSCROLL_ACTIVE_OFFSET - (bottom - clientY)) /
-              AUTOSCROLL_SPEED_RATIO
+          scrollingSpeed = Math.min(
+            Math.round(
+              (AUTOSCROLL_ACTIVE_OFFSET - (bottom - clientY)) /
+                AUTOSCROLL_SPEED_RATIO
+            ),
+            Math.round(
+              (delta - AUTOSCROLL_DELTA_THRESHOLD) / AUTOSCROLL_SPEED_RATIO
+            )
           );
         }
         if (this.state.scrollingSpeed !== scrollingSpeed) {

--- a/src/list.stories.tsx
+++ b/src/list.stories.tsx
@@ -12,6 +12,7 @@ import LockVerticallyExample from '../examples/LockVertically';
 import VaryingHeightsExample from '../examples/VaryingHeights';
 import ScrollingWindowExample from '../examples/ScrollingWindow';
 import ScrollingContainerExample from '../examples/ScrollingContainer';
+import ScrollingContainerShortExample from '../examples/ScrollingContainerShort';
 import InteractiveItemsExample from '../examples/InteractiveItems';
 import CustomComponentExample from '../examples/CustomComponent';
 import CustomContainerExample from '../examples/CustomContainer';
@@ -30,6 +31,7 @@ export const LockVertically = () => <LockVerticallyExample />;
 export const VaryingHeights = () => <VaryingHeightsExample />;
 export const ScrollingWindow = () => <ScrollingWindowExample />;
 export const ScrollingContainer = () => <ScrollingContainerExample />;
+export const ScrollingContainerShort = () => <ScrollingContainerShortExample />;
 export const ScrollingContainerWithHandle = () => (
   <ScrollingContainerHandleExample />
 );


### PR DESCRIPTION
Fixes https://github.com/tajo/react-movable/issues/68
Fixes https://github.com/tajo/react-movable/issues/80
Closes https://github.com/tajo/react-movable/pull/78

Rather than expose more configuration options to the user, this adds a movement threshold so that autoscroll does not happen until the item has been dragged more than 10 pixels, and ensures it autoscrolls only in the correct direction. 

Furthermore, the scroll speed is also adjusted for these cases, so that the speed is not so high when the starting position of the scroll is within the `AUTOSCROLL_ACTIVE_OFFSET`.

I confirmed that this does not break existing scroll behavior in tall containers / windows, and I added an example for this ("Scrolling container short"), but I'm not sure whether it's worth committing it or not.  I included it so that you could easily test out the fixes here, @tajo.  