### PR TITLE
fix: Use setState callback in finishDrop to avoid occasional flicker

### DIFF
--- a/.changeset/green-poems-shake.md
+++ b/.changeset/green-poems-shake.md
@@ -1,0 +1,5 @@
+---
+"react-movable": patch
+---
+
+Use setState callback in finishDrop to avoid occasional flicker

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -484,31 +484,33 @@ class List<Value = string> extends React.Component<IProps<Value>> {
         ? -1
         : Math.max(this.afterIndex, 0)
       : oldIndex;
-    if (removeItem || hasChanged) {
-      this.props.onChange({
-        oldIndex,
-        newIndex,
-        targetRect: this.ghostRef.current!.getBoundingClientRect(),
+    const targetRect = this.ghostRef.current!.getBoundingClientRect();
+    this.setState({ itemDragged: -1, scrollingSpeed: 0 }, () => {
+      if (removeItem || hasChanged) {
+        this.props.onChange({
+          oldIndex,
+          newIndex,
+          targetRect: targetRect,
+        });
+      }
+      this.props.afterDrag &&
+        this.props.afterDrag({
+          elements: this.getChildren(),
+          oldIndex,
+          newIndex,
+        });
+      this.getChildren().forEach((item) => {
+        setItemTransition(item, 0);
+        transformItem(item, null);
+        (item as HTMLElement).style.touchAction = "";
       });
-    }
-    this.props.afterDrag &&
-      this.props.afterDrag({
-        elements: this.getChildren(),
-        oldIndex,
-        newIndex,
-      });
-    this.getChildren().forEach((item) => {
-      setItemTransition(item, 0);
-      transformItem(item, null);
-      (item as HTMLElement).style.touchAction = "";
+      this.afterIndex = -2;
+      // sometimes the scroll gets messed up after the drop, fix:
+      if (this.lastScroll > 0) {
+        this.listRef.current!.scrollTop = this.lastScroll;
+        this.lastScroll = 0;
+      }
     });
-    this.setState({ itemDragged: -1, scrollingSpeed: 0 });
-    this.afterIndex = -2;
-    // sometimes the scroll gets messed up after the drop, fix:
-    if (this.lastScroll > 0) {
-      this.listRef.current!.scrollTop = this.lastScroll;
-      this.lastScroll = 0;
-    }
   };
 
   onKeyDown = (e: React.KeyboardEvent) => {


### PR DESCRIPTION
Fixes #113

As stated in #113 the list would sometimes flicker when drag ended.
This PR fixes this issue by synchronizing the order of the events in `finishDrop` using the callback of Reacts `setState`.

I was a bit worried that this fix would lead to excessive rendering, but it seems to work well when I test it in ladle.