### PR TITLE
fix: add check for element presence in "checkIfInteractive" utility

### DIFF
--- a/.changeset/spotty-pears-agree.md
+++ b/.changeset/spotty-pears-agree.md
@@ -1,0 +1,5 @@
+---
+"react-movable": patch
+---
+
+add check for element presence in "checkIfInteractive" utility

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-movable",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "type": "module",
   "description": "Drag and drop lists.",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-movable",
-  "version": "3.4.1",
+  "version": "3.4.0",
   "type": "module",
   "description": "Drag and drop lists.",
   "main": "lib/index.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,6 +120,8 @@ export function checkIfInteractive(target: Element, rootElement: Element) {
     "switch",
     "tab",
   ];
+  if (!target || !rootElement) return false;
+
   while (target !== rootElement) {
     if (target.getAttribute("data-movable-handle")) {
       return false;


### PR DESCRIPTION
* Noticed intermittent (<1%) uncaught errors from the usage of component in a application.
* I wasn't able to root cause the flow when this was happening. So adding a check in the utility to prevent component crashes in such instances

Test Plan
* Unit tests
* Sanity tested locally in ladle