### PR TITLE
`checkInteractive` was crashing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,6 +123,9 @@ export function checkIfInteractive(target: Element, rootElement: Element) {
   if (!target || !rootElement) return false;
 
   while (target !== rootElement) {
+    if (!target) {
+      return false;
+    }
     if (target.getAttribute("data-movable-handle")) {
       return false;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,6 +126,9 @@ export function checkIfInteractive(target: Element, rootElement: Element) {
     if (!target) {
       return false;
     }
+    if (target.tagName === 'HTML') {
+      return false;
+    }
     if (target.getAttribute("data-movable-handle")) {
       return false;
     }


### PR DESCRIPTION
`checkInteractive` was crashing when a modal was over the list and it was pressed a _ctrl key_ like (command or ctrl).

I am using MUI. I don't know if it happens with other modals.

But the `while` in `checkInteractive`  was going up until it get to the _html tag_ and it was breaking the `.getAttribute` This was only happening in chromium browsers.

Thanks